### PR TITLE
Fix regex expression in Scan Manga

### DIFF
--- a/src/fr/scanmanga/build.gradle
+++ b/src/fr/scanmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Scan-Manga'
     extClass = '.ScanManga'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
+++ b/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
@@ -202,12 +202,14 @@ class ScanManga : HttpSource() {
         val packedScript = document.selectFirst("script:containsData(h,u,n,t,e,r)")!!.data()
 
         val unpackedScript = decodeHunter(packedScript)
-        val parametersRegex = Regex("""sml = '([^']+)';\n.*var sme = '([^']+)'""")
+        val parametersRegex = Regex("""sml = '([^']+)';\n?.*var sme = '([^']+)'""")
 
-        val (sml, sme) = parametersRegex.find(unpackedScript)!!.destructured
+        val (sml, sme) = parametersRegex.find(unpackedScript)?.destructured
+            ?: error("Failed to extract parameters from script.")
 
         val chapterInfoRegex = Regex("""const idc = (\d+)""")
-        val (chapterId) = chapterInfoRegex.find(packedScript)!!.destructured
+        val (chapterId) = chapterInfoRegex.find(packedScript)?.destructured
+            ?: error("Failed to extract chapter ID.")
 
         val mediaType = "application/json; charset=UTF-8".toMediaType()
         val requestBody = """{"a":"$sme","b":"$sml"}"""


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension


Added some error to easily pinpoint where it fails when it fails.
Closes #10317